### PR TITLE
Fix all skills randomization

### DIFF
--- a/ignis/core/fe14/fe14_skills_vendor.py
+++ b/ignis/core/fe14/fe14_skills_vendor.py
@@ -11,17 +11,18 @@ class FE14SkillsVendor:
     ):
         self.gd = gd
         self.user_config = user_config
-        self.personal_skills = game_config.personal_skills
-        self.equip_skills = game_config.equip_skills
-        self.rand = rand
 
         rid, field_id = gd.table("skills")
+        seid_to_rid = gd.key_to_rid_mapping(rid, field_id)
+        self.personal_skills = [seid_to_rid[s] for s in game_config.personal_skills]
+        self.equip_skills = [seid_to_rid[s] for s in game_config.equip_skills]
+        self.rand = rand
+
         self.default_skill_rid = gd.list_get(rid, field_id, 0)
         self.all_skills = gd.items(rid, field_id)[1:]  # Get rid of the null skill.
         self.all_equip_skills = list(
             filter(lambda s: s not in self.personal_skills, self.all_skills)
         )
-        self.seid_to_rid = gd.key_to_rid_mapping(rid, field_id)
 
     def default_skill(self):
         return self.default_skill_rid
@@ -30,10 +31,10 @@ class FE14SkillsVendor:
         if self.user_config.include_all_skills_in_skill_pool:
             return self.rand.choice(self.all_skills)
         else:
-            return self.seid_to_rid[self.rand.choice(self.personal_skills)]
+            return self.rand.choice(self.personal_skills)
 
     def random_equip_skill(self):
         if self.user_config.include_all_skills_in_skill_pool:
             return self.rand.choice(self.all_equip_skills)
         else:
-            return self.seid_to_rid[self.rand.choice(self.equip_skills)]
+            return self.rand.choice(self.equip_skills)


### PR DESCRIPTION
Fixes #14 : Equip and personal skills were not separated properly when randomizing all skills, because of a useless comparison between SEIDs and RIDs.