### PR TITLE
Option to keep character stats when randomizing join order

### DIFF
--- a/ignis/controllers/fe14_user_config_form.py
+++ b/ignis/controllers/fe14_user_config_form.py
@@ -41,6 +41,7 @@ class FE14UserConfigForm(Ui_FE14UserConfigForm):
             include_amiibo_units_in_character_pool=self.amiibo_check_box.isChecked(),
             randomize_children=self.children_check_box.isChecked(),
             randomize_join_order=self.randomize_join_order_check_box.isChecked(),
+            characters_keep_their_own_stats=self.characters_keep_their_own_stats_check_box.isChecked(),
             randomize_player=self.player_check_box.isChecked(),
             same_sex_swaps_only=self.same_sex_only_check_box.isChecked(),
             separate_pool_for_corrinsexuals=self.corrinsexuals_pool_check_box.isChecked(),

--- a/ignis/core/fe14/fe14_character_vendor.py
+++ b/ignis/core/fe14/fe14_character_vendor.py
@@ -76,7 +76,7 @@ class FE14CharactersVendor:
             primary_class = gd.rid(rid, "class_1")
             c.class_level = classes.get_class_level(primary_class)
 
-        # Create the swaps list
+        # Create the swaps list (of [original_pid, replacement_pid] entries)
         # If join order randomization is disabled, use an identity mapping
         if user_config.randomize_join_order:
             shuffler = FE14CharacterShuffler(user_config, rand)

--- a/ignis/core/fe14/step/fe14_global_character_randomization_step.py
+++ b/ignis/core/fe14/step/fe14_global_character_randomization_step.py
@@ -53,7 +53,13 @@ class FE14GlobalCharacterRandomizationStep(RandomizationStep):
                     replacing.class_level,
                 )
 
-            fe14_utils.apply_randomized_stats(
-                gd, rand, replacing_rid, rid, stat_strategy, user_config.passes
-            )
+            if user_config.characters_keep_their_own_stats:
+                cached_rid = characters.get_original(char.pid)
+                fe14_utils.apply_randomized_stats(
+                    gd, rand, cached_rid, rid, stat_strategy, user_config.passes
+                )
+            else:
+                fe14_utils.apply_randomized_stats(
+                    gd, rand, replacing_rid, rid, stat_strategy, user_config.passes
+                )
         gd.set_store_dirty("gamedata", True)

--- a/ignis/model/fe14_user_config.py
+++ b/ignis/model/fe14_user_config.py
@@ -22,6 +22,7 @@ class FE14UserConfig:
     randomize_join_order: bool
     randomize_player: bool
     same_sex_swaps_only: bool
+    characters_keep_their_own_stats: bool
     songstress_sprite_fix: bool
     apply_animation_fixes: bool
     feral_dragon_head_fix: bool

--- a/ignis/views/ui_fe14_user_config_form.py
+++ b/ignis/views/ui_fe14_user_config_form.py
@@ -73,11 +73,16 @@ class Ui_FE14UserConfigForm(QWidget):
         self.corrinsexuals_pool_check_box = QCheckBox(
             'Use a Separate Pool for "Corrinsexuals"'
         )
+        self.characters_keep_their_own_stats_check_box = QCheckBox(
+            'Swapped characters keep their own stats'
+        )
+        self.same_sex_only_check_box.setChecked(True)
         join_order_layout = QVBoxLayout()
         join_order_layout.setAlignment(QtGui.Qt.AlignTop)
         join_order_layout.addWidget(self.randomize_join_order_check_box)
         join_order_layout.addWidget(self.same_sex_only_check_box)
         join_order_layout.addWidget(self.corrinsexuals_pool_check_box)
+        join_order_layout.addWidget(self.characters_keep_their_own_stats_check_box)
         join_order_box = QGroupBox("Join Order Randomization")
         join_order_box.setLayout(join_order_layout)
 


### PR DESCRIPTION
Fixes #16: Add a checkbox to make swapped characters carry over their own stats.